### PR TITLE
[修复] 拖动排序+子表产生数据异常的问题

### DIFF
--- a/ext/soulTable.js
+++ b/ext/soulTable.js
@@ -912,7 +912,16 @@ layui.define(['table', 'tableFilter', 'tableChild', 'tableMerge'], function (exp
               }
             });
 
-            var newIndex = $this.index()
+            var newIndex = $this.index();
+            var errorRowCount = 0;  // 异常的行 比如子表 等情况插入的 tr 
+            $.each($this.parent().find('tr'), function (i, o) {
+              if ($(o).data('index') == undefined) {
+                errorRowCount++;
+              } else if ($(o).data('index') == index){
+                return false;
+              }
+            })
+            newIndex -= errorRowCount;
 
             if (newIndex !== index) { // 有位置变动
               var cache = table.cache[tableId],

--- a/ext/soulTable.slim.js
+++ b/ext/soulTable.slim.js
@@ -894,7 +894,16 @@ layui.define(['table'], function (exports) {
                             }
                         });
 
-                        var newIndex = $this.index()
+                        var newIndex = $this.index();
+                        var errorRowCount = 0;  // 异常的行 比如子表 等情况插入的 tr 
+                        $.each($this.parent().find('tr'), function (i, o) {
+                            if ($(o).data('index') == undefined) {
+                                errorRowCount++;
+                            } else if ($(o).data('index') == index){
+                                return false;
+                            }
+                        })
+                        newIndex -= errorRowCount;
 
                         if (newIndex !== index) { // 有位置变动
                             var cache = table.cache[tableId],


### PR DESCRIPTION
如果展开了子表，那么会多一个 `tr` 从而导致 `index()` 不准 需要移除多余的 `tr`