### PR TITLE
update:修复如果filterSos不为空时，添加条件时data-id从1开始的问题

### DIFF
--- a/ext/tableFilter.js
+++ b/ext/tableFilter.js
@@ -1326,8 +1326,9 @@ layui.define(['table', 'form', 'laydate', 'util', 'excel', 'laytpl'], function (
             }
 
             _this.updateWhere(myTable, filterSo);
-
-            filterBoard.push('<li data-id="' + filterSo.id + '" data-field="' + filterSo.field + '" data-mode="' + filterSo.mode + '" data-type="' + filterSo.type + '" data-value="' + filterSo.value + '" data-prefix="' + filterSo.prefix + '" class="last">');
+            var filterSoJson = JSON.parse(where_cache[myTable.id].filterSos);
+            
+            filterBoard.push('<li data-id="' + (filterSoJson[filterSoJson.length].id+2)  + '" data-field="' + filterSo.field + '" data-mode="' + filterSo.mode + '" data-type="' + filterSo.type + '" data-value="' + filterSo.value + '" data-prefix="' + filterSo.prefix + '" class="last">');
             filterBoard.push('<div><table><tbody><tr><td data-type="top"></td></tr><tr><td data-type="bottom"></td></tr></tbody></table></div>');
             filterBoard.push('<div><input type="checkbox" name="switch" lay-filter="soul-edit-switch" lay-skin="switch" lay-text="与|或" checked></div>')
             filterBoard.push('<div class="layui-firebrick item-field">' + fieldMap[filterSo.field].title + '</div>');


### PR DESCRIPTION
如果存储filterSos的筛选结果，每次访问页面时保存上一次搜索的筛选结果，则在新增条件时生成的筛选条件的li标签上的data-id会从1开始计算，如果修改该li对应的列筛选条件时，则会将其他li标签上也是data-id的筛选条件进行修改，所以需要将li标签上的data-id作为页面唯一。拿全局条件缓存来计算data-id，则不会出现data-id重复的情况